### PR TITLE
Fix streaming methods

### DIFF
--- a/liboai/components/completions.cpp
+++ b/liboai/components/completions.cpp
@@ -9,6 +9,7 @@ liboai::Response liboai::Completions::create(const std::string& model_id, std::o
 	jcon.push_back("temperature", std::move(temperature));
 	jcon.push_back("top_p", std::move(top_p));
 	jcon.push_back("n", std::move(n));
+	jcon.push_back("stream", stream);
 	jcon.push_back("logprobs", std::move(logprobs));
 	jcon.push_back("echo", std::move(echo));
 	jcon.push_back("stop", std::move(stop));
@@ -25,7 +26,7 @@ liboai::Response liboai::Completions::create(const std::string& model_id, std::o
 		cpr::Body {
 			jcon.dump()
 		},
-		stream.has_value() ? cpr::WriteCallback{stream.value()} : cpr::WriteCallback{},
+		stream ? cpr::WriteCallback{std::move(stream.value())} : cpr::WriteCallback{},
 		this->auth_.GetProxies()
 	);
 
@@ -41,6 +42,7 @@ liboai::FutureResponse liboai::Completions::create_async(const std::string& mode
 	jcon.push_back("temperature", std::move(temperature));
 	jcon.push_back("top_p", std::move(top_p));
 	jcon.push_back("n", std::move(n));
+	jcon.push_back("stream", stream);
 	jcon.push_back("logprobs", std::move(logprobs));
 	jcon.push_back("echo", std::move(echo));
 	jcon.push_back("stop", std::move(stop));
@@ -55,10 +57,10 @@ liboai::FutureResponse liboai::Completions::create_async(const std::string& mode
 			return this->Request(
 				Method::HTTP_POST, "/completions", "application/json",
 				this->auth_.GetAuthorizationHeaders(),
-				cpr::Body{
+				cpr::Body {
 					jcon.dump()
 				},
-				stream.has_value() ? cpr::WriteCallback{ stream.value() } : cpr::WriteCallback{},
+				stream ? cpr::WriteCallback{std::move(stream.value())} : cpr::WriteCallback{},
 				this->auth_.GetProxies()
 			);
 		}

--- a/liboai/components/fine_tunes.cpp
+++ b/liboai/components/fine_tunes.cpp
@@ -48,7 +48,7 @@ liboai::FutureResponse liboai::FineTunes::create_async(const std::string& traini
 			return this->Request(
 				Method::HTTP_POST, "/fine-tunes", "application/json",
 				this->auth_.GetAuthorizationHeaders(),
-				cpr::Body{
+				cpr::Body {
 					jcon.dump()
 				},
 				this->auth_.GetProxies()
@@ -128,14 +128,14 @@ liboai::FutureResponse liboai::FineTunes::cancel_async(const std::string& fine_t
 
 liboai::Response liboai::FineTunes::list_events(const std::string& fine_tune_id, std::optional<std::function<bool(std::string, intptr_t)>> stream) const & noexcept(false) {
 	cpr::Parameters params;
-	stream.has_value() ? params.Add({ "stream", "true"}) : void();
+	stream ? params.Add({"stream", "true"}) : void();
 
 	cpr::Response res;
 	res = this->Request(
 		Method::HTTP_POST, "/fine-tunes/" + fine_tune_id + "/events", "application/json",
 		this->auth_.GetAuthorizationHeaders(),
 		std::move(params),
-		stream.has_value() ? cpr::WriteCallback{stream.value()} : cpr::WriteCallback{},
+		stream ? cpr::WriteCallback{std::move(stream.value())} : cpr::WriteCallback{},
 		this->auth_.GetProxies()
 	);
 
@@ -144,7 +144,7 @@ liboai::Response liboai::FineTunes::list_events(const std::string& fine_tune_id,
 
 liboai::FutureResponse liboai::FineTunes::list_events_async(const std::string& fine_tune_id, std::optional<std::function<bool(std::string, intptr_t)>> stream) const & noexcept(false) {
 	cpr::Parameters params;
-	stream.has_value() ? params.Add({ "stream", "true"}) : void();
+	stream ? params.Add({ "stream", "true"}) : void();
 
 	return std::async(
 		std::launch::async, [&, params]() -> liboai::Response {
@@ -152,7 +152,7 @@ liboai::FutureResponse liboai::FineTunes::list_events_async(const std::string& f
 				Method::HTTP_POST, "/fine-tunes/" + fine_tune_id + "/events", "application/json",
 				this->auth_.GetAuthorizationHeaders(),
 				std::move(params),
-				stream.has_value() ? cpr::WriteCallback{ stream.value() } : cpr::WriteCallback{},
+				stream ? cpr::WriteCallback{std::move(stream.value())} : cpr::WriteCallback{},
 				this->auth_.GetProxies()
 			);
 		}

--- a/liboai/components/images.cpp
+++ b/liboai/components/images.cpp
@@ -48,11 +48,11 @@ liboai::Response liboai::Images::create_edit(const std::filesystem::path& image,
 		{ "prompt", prompt },
 		{ "image", cpr::File{image.generic_string()} }
 	};
-	if (mask.has_value()) { form.parts.push_back({ "mask", cpr::File{mask.value().generic_string()} }); }
-	if (n.has_value()) { form.parts.push_back({ "n", n.value() }); }
-	if (size.has_value()) { form.parts.push_back({ "size", size.value() }); }
-	if (response_format.has_value()) { form.parts.push_back({ "response_format", response_format.value() }); }
-	if (user.has_value()) { form.parts.push_back({ "user", user.value() }); }
+	if (mask) { form.parts.push_back({ "mask", cpr::File{mask.value().generic_string()} }); }
+	if (n) { form.parts.push_back({ "n", n.value() }); }
+	if (size) { form.parts.push_back({ "size", size.value() }); }
+	if (response_format) { form.parts.push_back({ "response_format", response_format.value() }); }
+	if (user) { form.parts.push_back({ "user", user.value() }); }
 	
 	cpr::Response res;
 	res = this->Request(
@@ -70,11 +70,11 @@ liboai::FutureResponse liboai::Images::create_edit_async(const std::filesystem::
 		{ "prompt", prompt },
 		{ "image", cpr::File{image.generic_string()} }
 	};
-	if (mask.has_value()) { form.parts.push_back({ "mask", cpr::File{mask.value().generic_string()} }); }
-	if (n.has_value()) { form.parts.push_back({ "n", n.value() }); }
-	if (size.has_value()) { form.parts.push_back({ "size", size.value() }); }
-	if (response_format.has_value()) { form.parts.push_back({ "response_format", response_format.value() }); }
-	if (user.has_value()) { form.parts.push_back({ "user", user.value() }); }
+	if (mask) { form.parts.push_back({ "mask", cpr::File{mask.value().generic_string()} }); }
+	if (n) { form.parts.push_back({ "n", n.value() }); }
+	if (size) { form.parts.push_back({ "size", size.value() }); }
+	if (response_format) { form.parts.push_back({ "response_format", response_format.value() }); }
+	if (user) { form.parts.push_back({ "user", user.value() }); }
 
 	return std::async(
 		std::launch::async, [&, form]() -> liboai::Response {
@@ -92,10 +92,10 @@ liboai::Response liboai::Images::create_variation(const std::filesystem::path& i
 	cpr::Multipart form = {
 		{ "image", cpr::File{image.generic_string()} }
 	};
-	if (n.has_value()) { form.parts.push_back({ "n", n.value() }); }
-	if (size.has_value()) { form.parts.push_back({ "size", size.value() }); }
-	if (response_format.has_value()) { form.parts.push_back({ "response_format", response_format.value() }); }
-	if (user.has_value()) { form.parts.push_back({ "user", user.value() }); }
+	if (n) { form.parts.push_back({ "n", n.value() }); }
+	if (size) { form.parts.push_back({ "size", size.value() }); }
+	if (response_format) { form.parts.push_back({ "response_format", response_format.value() }); }
+	if (user) { form.parts.push_back({ "user", user.value() }); }
 	
 	cpr::Response res;
 	res = this->Request(
@@ -112,10 +112,10 @@ liboai::FutureResponse liboai::Images::create_variation_async(const std::filesys
 	cpr::Multipart form = {
 		{ "image", cpr::File{image.generic_string()} }
 	};
-	if (n.has_value()) { form.parts.push_back({ "n", n.value() }); }
-	if (size.has_value()) { form.parts.push_back({ "size", size.value() }); }
-	if (response_format.has_value()) { form.parts.push_back({ "response_format", response_format.value() }); }
-	if (user.has_value()) { form.parts.push_back({ "user", user.value() }); }
+	if (n) { form.parts.push_back({ "n", n.value() }); }
+	if (size) { form.parts.push_back({ "size", size.value() }); }
+	if (response_format) { form.parts.push_back({ "response_format", response_format.value() }); }
+	if (user) { form.parts.push_back({ "user", user.value() }); }
 
 	return std::async(
 		std::launch::async, [&, form]() -> liboai::Response {

--- a/liboai/include/core/response.h
+++ b/liboai/include/core/response.h
@@ -36,7 +36,14 @@ namespace liboai {
 
 			template <class _Ty>
 			void push_back(std::string_view key, const _Ty& value) {
-				this->_json[key.data()] = value;
+				if constexpr (std::is_same_v<_Ty, std::optional<std::function<bool(std::string, intptr_t)>>>) {
+					if (value) {
+						this->_json[key.data()] = true;
+					}
+				}
+				else {
+					this->_json[key.data()] = value;
+				}
 			}
 
 			template <class _Ty>


### PR DESCRIPTION
Methods `liboai::Completions::create` and its associated `create_async` did not properly implement SSE streaming functionality.
* These methods failed to provide the necessary stream indicator in JSON data to allow the OpenAI API to stream back results as SSEs.

This PR adds/fixes the following:
* Adds a compile-time check to template method `liboai::JsonConstructor::push_back(... const _Ty&)` such that any optional stream callback for stream-able methods, when passed to this method, can be properly applied if valid.
   * In simple words, this method now checks if a supplied optional callback is valid and, if it is, provides `true` to the API call, and `false` otherwise, allowing streaming to function properly.
* Small syntactical changes.
* Now moves callback into the constructor of `cpr::WriteCallback`.