### PR TITLE
Fixed All Typos!

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -204,7 +204,7 @@ int main() {
 </table>
 
 <br>
-<p>After a succesful run of the above snippet, the file found at the URL returned from the component call will be download to the path <code>C:/some/folder/file.png</code>.
+<p>After a successful run of the above snippet, the file found at the URL returned from the component call will be download to the path <code>C:/some/folder/file.png</code>.
 <br>
 
 <h1>Synopsis</h1>

--- a/documentation/installation/README.md
+++ b/documentation/installation/README.md
@@ -36,7 +36,7 @@
   2. Create a new C++ project.
   3. Import the <code>liboai</code> source code (.cpp and .h files).
   4. *Link your project to the cURL library.
-  5. *Make sure you are targetting C++17.
+  5. *Make sure you are targeting C++17.
   6. *Compile as a static or dynamic library.
   
 <p>Now, in the project you'd like to integrate <code>liboai</code> into:

--- a/liboai/include/core/response.h
+++ b/liboai/include/core/response.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-	respone.h : liboai response container implementation.
+	response.h : liboai response container implementation.
 		This header file provides declarations for the liboai Response
 		implementation. Each component class will include this header
 		and use the Response class to return data to the user.


### PR DESCRIPTION
While trying to implement liboai into a project of my own, I had a bit of troubleshooting getting the [nlohmann/json](https://github.com/nlohmann/json) library to link up correctly, but while fixing it I noticed there was a simple typo in line 4 of [`liboai/include/core/response.h`](https://github.com/D7EAD/liboai/blob/main/liboai/include/core/response.h), so I got bored and went through all the files in the project & fixed typos! I just used a spell checker extension for vscode, so there might be some sneaky typo out there, but I doubt it.