### PR TITLE
v3.1.1 Hotfix

### DIFF
--- a/liboai/core/netimpl.cpp
+++ b/liboai/core/netimpl.cpp
@@ -1168,10 +1168,12 @@ void liboai::netimpl::Session::SetHeader(const components::Header& header) {
         }
     }
 
-    curl_slist* temp = curl_slist_append(this->headers, "Transfer-Encoding:chunked");
-    if (temp) {
-		this->headers = temp;
-    }
+	curl_slist* temp;
+//  Causes cURL error for simple GET requests
+//    curl_slist* temp = curl_slist_append(this->headers, "Transfer-Encoding: chunked");
+//    if (temp) {
+//		this->headers = temp;
+//    }
 
 	// remove preset curl headers for files >1MB
     temp = curl_slist_append(this->headers, "Expect:");

--- a/liboai/include/components/chat.h
+++ b/liboai/include/components/chat.h
@@ -133,6 +133,19 @@ namespace liboai {
 			LIBOAI_EXPORT bool Update(const Response& response) & noexcept(false);
 
 			/*
+				@brief Appends stream data (SSEs) from streamed methods.
+					This method updates the conversation given a token from a
+					streamed method. This method should be used when using
+					streamed methods such as ChatCompletion::create or 
+					create_async with a callback supplied. This function should
+					be called from within the stream's callback function
+					receiving the SSEs.
+
+					@param *token The token to update the conversation with.
+			*/
+//			LIBOAI_EXPORT bool AppendToken(std::string_view token) & noexcept(false);
+
+			/*
 				@brief Returns the raw JSON dump of the internal conversation object
 					in string format.
 			*/


### PR DESCRIPTION
This patch fixes the following:

* Fixes issues with some methods failing, such as, but not limited to:
  * `liboai::FineTune::list()` and `liboai::FineTune::list_async()`
  * `liboai::Model::list()` and `liboai::Model::list_async()`
  * `liboai::Files::list()` and `liboai::Files::list_async()`
    * These issues were caused by `Transfer-Encoding: chunked` being set.