### PR TITLE
Reorder intialization to erase warning(NFC)

### DIFF
--- a/liboai/include/core/exception.h
+++ b/liboai/include/core/exception.h
@@ -40,12 +40,12 @@ namespace liboai {
 		class OpenAIException : public std::exception {
 			public:
 				OpenAIException() = default;
-				OpenAIException(const OpenAIException& rhs) noexcept
-					: data_(rhs.data_), error_type_(rhs.error_type_), locale_(rhs.locale_) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
+                                OpenAIException(const OpenAIException& rhs) noexcept
+					: error_type_(rhs.error_type_), data_(rhs.data_), locale_(rhs.locale_) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
 				OpenAIException(OpenAIException&& rhs) noexcept
-					: data_(std::move(rhs.data_)), error_type_(rhs.error_type_), locale_(std::move(rhs.locale_)) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
+					: error_type_(rhs.error_type_), data_(std::move(rhs.data_)), locale_(std::move(rhs.locale_)) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
 				OpenAIException(std::string_view data, EType error_type, std::string_view locale) noexcept
-					: data_(data), error_type_(error_type), locale_(locale) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
+					: error_type_(error_type), data_(data), locale_(locale) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
 
 				const char* what() const noexcept override {
 					return this->fmt_str_.c_str();
@@ -64,11 +64,11 @@ namespace liboai {
 			public:
 				OpenAIRateLimited() = default;
 				OpenAIRateLimited(const OpenAIRateLimited& rhs) noexcept
-					: data_(rhs.data_), error_type_(rhs.error_type_), locale_(rhs.locale_) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
+					: error_type_(rhs.error_type_), data_(rhs.data_), locale_(rhs.locale_) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
 				OpenAIRateLimited(OpenAIRateLimited&& rhs) noexcept
-					: data_(std::move(rhs.data_)), error_type_(rhs.error_type_), locale_(std::move(rhs.locale_)) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
+					: error_type_(rhs.error_type_), data_(std::move(rhs.data_)), locale_(std::move(rhs.locale_)) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
 				OpenAIRateLimited(std::string_view data, EType error_type, std::string_view locale) noexcept
-					: data_(data), error_type_(error_type), locale_(locale) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
+					: error_type_(error_type), data_(data), locale_(locale) { this->fmt_str_ = (this->locale_ + ": " + this->data_ + " (" + this->GetETypeString(this->error_type_) + ")"); }
 
 				const char* what() const noexcept override {
 					return this->fmt_str_.c_str();

--- a/liboai/include/core/netimpl.h
+++ b/liboai/include/core/netimpl.h
@@ -576,8 +576,8 @@ namespace liboai {
 			class WriteCallback final {
 				public:
 					WriteCallback() = default;
-					WriteCallback(const WriteCallback& other) : callback(other.callback), userdata(other.userdata) {}
-					WriteCallback(WriteCallback&& old) noexcept : callback(std::move(old.callback)), userdata(std::move(old.userdata)) {}
+					WriteCallback(const WriteCallback& other) : userdata(other.userdata), callback(other.callback) {}
+					WriteCallback(WriteCallback&& old) noexcept : userdata(std::move(old.userdata)), callback(std::move(old.callback)) {}
 					WriteCallback(std::function<bool(std::string data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0)
 						: userdata(p_userdata), callback(std::move(p_callback)) {}
 


### PR DESCRIPTION

On Ubuntu 22.04, GCC warns that the initialization order doesn't match the member declaration order.

Let's erase it if it's unintentional. :)

```bash
[1/2] Building CXX object CMakeFiles/cegss.dir/main.cpp.o
In file included from /home/khei4/git/liboai/liboai/include/components/../core/network.h:18,
                 from /home/khei4/git/liboai/liboai/include/components/../core/authorization.h:19,
                 from /home/khei4/git/liboai/liboai/include/components/audio.h:14,
                 from /home/khei4/git/liboai/liboai/include/liboai.h:31,
                 from /home/khei4/git/cegss/main.cpp:7:
/home/khei4/git/liboai/liboai/include/components/../core/netimpl.h: In copy constructor ‘liboai::netimpl::components::WriteCallback::WriteCallback(const liboai::netimpl::components::WriteCallback&)’:
/home/khei4/git/liboai/liboai/include/components/../core/netimpl.h:600:98: warning: ‘liboai::netimpl::components::WriteCallback::callback’ will be initialized after [-Wreorder]
  600 |                                         std::function<bool(std::string data, intptr_t userdata)> callback;
      |                                                                                                  ^~~~~~~~
/home/khei4/git/liboai/liboai/include/components/../core/netimpl.h:599:50: warning:   ‘intptr_t liboai::netimpl::components::WriteCallback::userdata’ [-Wreorder]
  599 |                                         intptr_t userdata{};
      |  
```