### PR TITLE
Remove CONFIG option when looking for CURL to allow detecting system library on Ubuntu

### DIFF
--- a/liboai/CMakeLists.txt
+++ b/liboai/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 project(oai)
 
 find_package(nlohmann_json CONFIG REQUIRED)
-find_package(CURL CONFIG REQUIRED)
+find_package(CURL REQUIRED)
 
 add_library(oai
 components/audio.cpp


### PR DESCRIPTION
This removes the CONFIG option in the `find_package` CMake instruction. That option prevents using the system CURL on Ubuntu (and probably other distros).