### PR TITLE
Add optional peer CA verification

### DIFF
--- a/liboai/core/netimpl.cpp
+++ b/liboai/core/netimpl.cpp
@@ -39,6 +39,24 @@ liboai::netimpl::CurlHolder::CurlHolder() {
 	#if defined(LIBOAI_DEBUG)
 		curl_easy_setopt(this->curl_, CURLOPT_VERBOSE, 1L);
 	#endif
+
+	#if defined(LIBOAI_DISABLE_PEERVERIFY)
+		#if defined(LIBOAI_DEBUG)
+			_liboai_dbg(
+				"[dbg] [@%s] LIBOAI_DISABLE_PEERVERIFY set; peer verification disabled.\n",
+				__func__
+			);
+		#endif
+		curl_easy_setopt(this->curl_, CURLOPT_SSL_VERIFYPEER, 0L);
+	#else
+		#if defined(LIBOAI_DEBUG)
+			_liboai_dbg(
+				"[dbg] [@%s] LIBOAI_DISABLE_PEERVERIFY not set; peer verification enabled.\n",
+				__func__
+			);
+		#endif
+		curl_easy_setopt(this->curl_, CURLOPT_SSL_VERIFYPEER, 1L);
+	#endif
 }
 
 liboai::netimpl::CurlHolder::~CurlHolder() {


### PR DESCRIPTION
Fix for #51.

This PR allows users to optionally disable cURL peer certificate verification as seen [here](https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html) via a pre-processor definition `LIBOAI_DISABLE_PEERVERIFY`. If the pre-processor definition is not defined at compile-time, then cURL default behaviors will be used (peer certificate verification will be enabled).