### PR TITLE
CMake improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.vs
 build
+out
 TestApp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(liboai)
+
+option(BUILD_EXAMPLES "Build example applications" OFF)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+add_subdirectory(liboai)
+
+if(BUILD_EXAMPLES)
+  add_subdirectory(documentation)
+endif()
+
+set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT oai)

--- a/README.md
+++ b/README.md
@@ -96,4 +96,6 @@ int main() {
 <h1>Contributing</h1>
 <p>Artificial intelligence is an exciting and quickly-changing field. 
 
-If you'd like to partake in further placing the power of AI in the hands of everyday people, please consider contributing by either submitting new code and features via a **Pull Request**. If you have any issues using the library, or just want to suggest new features, feel free to contact me directly using the info on my <a href="https://github.com/D7EAD">profile</a> or open an **Issue**.
+If you'd like to partake in further placing the power of AI in the hands of everyday people, please consider contributing by submitting new code and features via a **Pull Request**. If you have any issues using the library, or just want to suggest new features, feel free to contact me directly using the info on my <a href="https://github.com/D7EAD">profile</a> or open an **Issue**.
+
+Please note that all Pull Requests should target the [dev](https://github.com/D7EAD/liboai/tree/dev) branch where additions will be tested and pushed to `main` once finalized.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - [x] [ChatGPT](https://github.com/D7EAD/liboai/tree/main/documentation/chat)
 - [X] [Audio](https://github.com/D7EAD/liboai/tree/main/documentation/audio)
 - [X] [Azure](https://github.com/D7EAD/liboai/tree/main/documentation/azure)
-- [X] [Functions](https://platform.openai.com/docs/api-reference/chat/create) ([v4.0.0-dev](https://github.com/D7EAD/liboai/tree/v4.0.0-dev))
+- [X] [Functions](https://platform.openai.com/docs/api-reference/chat/create)
 - [x] [Image DALL·E](https://github.com/D7EAD/liboai/tree/main/documentation/images)
 - [x] [Models](https://github.com/D7EAD/liboai/tree/main/documentation/models)
 - [x] [Completions](https://github.com/D7EAD/liboai/tree/main/documentation/completions) 

--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(documentation)
+
+macro(add_example target_name source_name)
+  add_executable(${target_name} "${source_name}")
+  target_link_libraries(${target_name} oai)
+  set_target_properties(${target_name} PROPERTIES FOLDER "examples/${PROJECT_NAME}")
+endmacro()
+
+macro(add_basic_example source_base_name)
+  add_example(${source_base_name} "${source_base_name}.cpp")
+endmacro()
+
+add_subdirectory(audio/examples)
+add_subdirectory(authorization/examples)
+add_subdirectory(azure/examples)
+add_subdirectory(chat/examples)
+add_subdirectory(chat/conversation/examples)
+add_subdirectory(completions/examples)
+add_subdirectory(edits/examples)
+add_subdirectory(embeddings/examples)  
+add_subdirectory(files/examples)
+add_subdirectory(fine-tunes/examples)
+add_subdirectory(images/examples)
+add_subdirectory(models/examples)
+add_subdirectory(moderations/examples)

--- a/documentation/audio/examples/CMakeLists.txt
+++ b/documentation/audio/examples/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(audio)
+
+add_basic_example(create_speech)
+add_basic_example(create_speech_async)
+add_basic_example(create_transcription)
+add_basic_example(create_transcription_async)
+add_basic_example(create_translation)
+add_basic_example(create_translation_async)

--- a/documentation/audio/examples/create_speech.cpp
+++ b/documentation/audio/examples/create_speech.cpp
@@ -1,4 +1,4 @@
-#include "liboai/include/liboai.h"
+#include "include/liboai.h"
 
 using namespace liboai;
 

--- a/documentation/audio/examples/create_speech.cpp
+++ b/documentation/audio/examples/create_speech.cpp
@@ -1,4 +1,4 @@
-#include "include/liboai.h"
+#include "liboai.h"
 
 using namespace liboai;
 

--- a/documentation/audio/examples/create_speech_async.cpp
+++ b/documentation/audio/examples/create_speech_async.cpp
@@ -1,4 +1,4 @@
-#include "liboai/include/liboai.h"
+#include "include/liboai.h"
 
 using namespace liboai;
 

--- a/documentation/audio/examples/create_speech_async.cpp
+++ b/documentation/audio/examples/create_speech_async.cpp
@@ -1,4 +1,4 @@
-#include "include/liboai.h"
+#include "liboai.h"
 
 using namespace liboai;
 

--- a/documentation/authorization/examples/CMakeLists.txt
+++ b/documentation/authorization/examples/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(authorization)
+
+add_basic_example(set_azure_key)
+add_basic_example(set_azure_key_env)
+add_basic_example(set_azure_key_file)
+add_basic_example(set_key)
+add_basic_example(set_key_env_var)
+add_basic_example(set_key_file)
+add_basic_example(set_organization)
+add_basic_example(set_organization_env_var)
+add_basic_example(set_organization_file)
+add_basic_example(set_proxies)
+add_basic_example(set_proxy_auth)

--- a/documentation/authorization/examples/set_azure_key.cpp
+++ b/documentation/authorization/examples/set_azure_key.cpp
@@ -5,6 +5,6 @@ using namespace liboai;
 int main() {
   OpenAI oai;
   if (oai.auth.SetAzureKey("hard-coded-key")) { // NOT recommended
-    ...
+    // ...
   }
 }

--- a/documentation/authorization/examples/set_azure_key_env.cpp
+++ b/documentation/authorization/examples/set_azure_key_env.cpp
@@ -5,6 +5,6 @@ using namespace liboai;
 int main() {
   OpenAI oai;
   if (oai.auth.SetAzureKeyEnv("AZURE_API_KEY")) {
-    ...
+    // ...
   }
 }

--- a/documentation/authorization/examples/set_azure_key_file.cpp
+++ b/documentation/authorization/examples/set_azure_key_file.cpp
@@ -5,6 +5,6 @@ using namespace liboai;
 int main() {
   OpenAI oai;
   if (oai.auth.SetAzureKeyFile("C:/some/folder/key.dat")) {
-    ...
+    // ...
   }
 }

--- a/documentation/authorization/examples/set_key.cpp
+++ b/documentation/authorization/examples/set_key.cpp
@@ -5,6 +5,6 @@ using namespace liboai;
 int main() {
   OpenAI oai;
   if (oai.auth.SetKey("hard-coded-key")) { // NOT recommended
-    ...
+    // ...
   }
 }

--- a/documentation/authorization/examples/set_key_env_var.cpp
+++ b/documentation/authorization/examples/set_key_env_var.cpp
@@ -5,6 +5,6 @@ using namespace liboai;
 int main() {
   OpenAI oai;
   if (oai.auth.SetKeyEnv("OPENAI_API_KEY")) {
-    ...
+    // ...
   }
 }

--- a/documentation/authorization/examples/set_key_file.cpp
+++ b/documentation/authorization/examples/set_key_file.cpp
@@ -5,6 +5,6 @@ using namespace liboai;
 int main() {
   OpenAI oai;
   if (oai.auth.SetKeyFile("C:/some/folder/key.dat")) {
-    ...
+    // ...
   }
 }

--- a/documentation/authorization/examples/set_organization.cpp
+++ b/documentation/authorization/examples/set_organization.cpp
@@ -5,6 +5,6 @@ using namespace liboai;
 int main() {
   OpenAI oai;
   if (oai.auth.SetKeyEnv("OPENAI_API_KEY") && oai.auth.SetOrganization("org-123")) {
-    ...
+    // ...
   }
 }

--- a/documentation/authorization/examples/set_organization_env_var.cpp
+++ b/documentation/authorization/examples/set_organization_env_var.cpp
@@ -5,6 +5,6 @@ using namespace liboai;
   int main() {
   OpenAI oai;
   if (oai.auth.SetKeyEnv("OPENAI_API_KEY") && oai.auth.SetOrganizationEnv("OPENAI_ORG_ID")) {
-    ...
+    // ...
   }
 }

--- a/documentation/authorization/examples/set_organization_file.cpp
+++ b/documentation/authorization/examples/set_organization_file.cpp
@@ -5,6 +5,6 @@ using namespace liboai;
 int main() {
   OpenAI oai;
   if (oai.auth.SetKeyEnv("OPENAI_API_KEY") && oai.auth.SetOrganizationFile("C:/some/folder/org.dat")) {
-    ...
+    // ...
   }
 }

--- a/documentation/authorization/examples/set_proxies.cpp
+++ b/documentation/authorization/examples/set_proxies.cpp
@@ -16,6 +16,6 @@ int main() {
   });
 
   if (oai.auth.SetKeyEnv("OPENAI_API_KEY")) {
-    ...
+    // ...
   }
 }

--- a/documentation/authorization/examples/set_proxy_auth.cpp
+++ b/documentation/authorization/examples/set_proxy_auth.cpp
@@ -26,6 +26,6 @@ int main() {
   });
 
   if (oai.auth.SetKeyEnv("OPENAI_API_KEY")) {
-    ...
+    // ...
   }
 }

--- a/documentation/azure/examples/CMakeLists.txt
+++ b/documentation/azure/examples/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(azure)
+
+add_example(create_chat_completion_azure "create_chat_completion.cpp")
+add_example(create_chat_completion_async_azure "create_chat_completion_async.cpp")
+add_basic_example(create_completion)
+add_basic_example(create_completion_async)
+add_example(create_embedding_azure "create_embedding.cpp")
+add_example(create_embedding_async_azure "create_embedding_async.cpp")
+add_basic_example(delete_generated_image)
+add_basic_example(delete_generated_image_async)
+add_basic_example(get_generated_image)
+add_basic_example(get_generated_image_async)
+add_basic_example(request_image_generation)
+add_basic_example(request_image_generation_async)

--- a/documentation/chat/conversation/examples/CMakeLists.txt
+++ b/documentation/chat/conversation/examples/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(conversation)
+
+add_basic_example(adduserdata)
+add_basic_example(getjsonobject)
+add_basic_example(getlastresponse)
+add_basic_example(getrawconversation)
+add_basic_example(poplastresponse)
+add_basic_example(popsystemdata)
+add_basic_example(popuserdata)
+add_basic_example(setsystemdata)
+add_basic_example(update)

--- a/documentation/chat/conversation/examples/adduserdata.cpp
+++ b/documentation/chat/conversation/examples/adduserdata.cpp
@@ -11,5 +11,5 @@ int main() {
   // add user data - such as a question
   convo.AddUserData("What is the meaning of life?");
 
-  ...
+  // ...
 }

--- a/documentation/chat/conversation/examples/popsystemdata.cpp
+++ b/documentation/chat/conversation/examples/popsystemdata.cpp
@@ -17,5 +17,5 @@ int main() {
   // add a different system message
   convo.SetSystemData("You are a helpful bot that enjoys business.");
 
-  ...
+  // ...
 }

--- a/documentation/chat/conversation/examples/popuserdata.cpp
+++ b/documentation/chat/conversation/examples/popuserdata.cpp
@@ -17,5 +17,5 @@ int main() {
   // add different user data
   convo.AddUserData("What is the size of the universe?");
 
-  ...
+  // ...
 }

--- a/documentation/chat/conversation/examples/setsystemdata.cpp
+++ b/documentation/chat/conversation/examples/setsystemdata.cpp
@@ -11,5 +11,5 @@ int main() {
   // set system message to guide the chat model
   convo.SetSystemData("You are helpful bot.");
 
-  ...
+  // ...
 }

--- a/documentation/chat/examples/CMakeLists.txt
+++ b/documentation/chat/examples/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(chat)
+
+add_basic_example(create_chat_completion)
+add_basic_example(create_chat_completion_async)
+add_basic_example(ongoing_user_convo)

--- a/documentation/completions/examples/CMakeLists.txt
+++ b/documentation/completions/examples/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(completions)
+
+add_basic_example(generate_completion)
+add_basic_example(generate_completion_async)

--- a/documentation/edits/examples/CMakeLists.txt
+++ b/documentation/edits/examples/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(edits)
+
+add_basic_example(create_edit)
+add_basic_example(create_edit_async)

--- a/documentation/embeddings/examples/CMakeLists.txt
+++ b/documentation/embeddings/examples/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(embeddings)
+
+add_basic_example(create_embedding)
+add_basic_example(create_embedding_async)

--- a/documentation/files/examples/CMakeLists.txt
+++ b/documentation/files/examples/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(files)
+
+add_basic_example(delete_file)
+add_basic_example(delete_file_async)
+add_basic_example(download_uploaded_file)
+add_basic_example(download_uploaded_file_async)
+add_basic_example(list_files)
+add_basic_example(list_files_async)
+add_basic_example(retrieve_file)
+add_basic_example(retrieve_file_async)
+add_basic_example(upload_file)
+add_basic_example(upload_file_async)

--- a/documentation/fine-tunes/examples/CMakeLists.txt
+++ b/documentation/fine-tunes/examples/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(fine-tunes)
+
+add_basic_example(cancel_fine_tune)
+add_basic_example(cancel_fine_tune_async)
+add_basic_example(create_fine_tune)
+add_basic_example(create_fine_tune_async)
+add_basic_example(delete_fine_tune_model)
+add_basic_example(delete_fine_tune_model_async)
+add_basic_example(list_fine_tune_events)
+add_basic_example(list_fine_tune_events_async)
+add_basic_example(list_fine_tunes)
+add_basic_example(list_fine_tunes_async)
+add_basic_example(retrieve_fine_tune)
+add_basic_example(retrieve_fine_tune_async)

--- a/documentation/images/examples/CMakeLists.txt
+++ b/documentation/images/examples/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(images)
+
+# compilation error
+#add_basic_example(download_generated_image)
+add_basic_example(generate_edit)
+add_basic_example(generate_edit_async)
+add_basic_example(generate_image)
+add_basic_example(generate_image_async)
+add_basic_example(generate_variation)
+add_basic_example(generate_variation_async)

--- a/documentation/models/examples/CMakeLists.txt
+++ b/documentation/models/examples/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(models)
+
+add_basic_example(list_models)
+add_basic_example(list_models_async)
+add_basic_example(retrieve_model)
+add_basic_example(retrieve_model_async)

--- a/documentation/moderations/examples/CMakeLists.txt
+++ b/documentation/moderations/examples/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(moderations)
+
+add_basic_example(create_moderation)
+add_basic_example(create_moderation_async)

--- a/liboai/CMakeLists.txt
+++ b/liboai/CMakeLists.txt
@@ -1,54 +1,136 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
-project(oai)
+include(CMakePackageConfigHelpers)
+
+project(oai VERSION 4.0.1)
+
+if(MSVC)
+  set(CMAKE_DEBUG_POSTFIX "d")
+endif()
 
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(CURL REQUIRED)
 
-add_library(oai
-components/audio.cpp
-components/azure.cpp
-components/chat.cpp
-components/completions.cpp
-components/edits.cpp
-components/embeddings.cpp
-components/files.cpp
-components/fine_tunes.cpp
-components/images.cpp
-components/models.cpp
-components/moderations.cpp
-core/authorization.cpp
-core/netimpl.cpp
-core/response.cpp
+add_library(${PROJECT_NAME})
+
+function(make_absolute_paths result_var)
+    set(absolute_paths)
+    foreach(file IN LISTS ARGN)
+        list(APPEND absolute_paths "${CMAKE_CURRENT_SOURCE_DIR}/${file}")
+    endforeach()
+    set(${result_var} "${absolute_paths}" PARENT_SCOPE)
+endfunction()
+
+set(HEADERS_RELATIVE
+  "include/liboai.h"
 )
 
-target_compile_features(oai PRIVATE cxx_std_17)
+make_absolute_paths(HEADERS ${HEADERS_RELATIVE})
+source_group("include" FILES ${HEADERS})
 
-target_link_libraries(oai PRIVATE nlohmann_json::nlohmann_json)
-target_link_libraries(oai PRIVATE CURL::libcurl)
+set(COMPONENT_HEADERS_RELATIVE
+  "include/components/audio.h"
+  "include/components/azure.h"
+  "include/components/chat.h"
+  "include/components/completions.h"
+  "include/components/edits.h"
+  "include/components/embeddings.h"
+  "include/components/files.h"
+  "include/components/fine_tunes.h"
+  "include/components/images.h"
+  "include/components/models.h"
+  "include/components/moderations.h"
+)
 
-install(TARGETS oai DESTINATION lib)
-#not needed anymore
-#install(FILES liboai.h DESTINATION include)
+make_absolute_paths(COMPONENT_HEADERS ${COMPONENT_HEADERS_RELATIVE})
+source_group("include/components" FILES ${COMPONENT_HEADERS})
+
+set(COMPONENT_SOURCES_RELATIVE
+  "components/audio.cpp"
+  "components/azure.cpp"
+  "components/chat.cpp"
+  "components/completions.cpp"
+  "components/edits.cpp"
+  "components/embeddings.cpp"
+  "components/files.cpp"
+  "components/fine_tunes.cpp"
+  "components/images.cpp"
+  "components/models.cpp"
+  "components/moderations.cpp"
+)
+
+make_absolute_paths(COMPONENT_SOURCES ${COMPONENT_SOURCES_RELATIVE})
+source_group("source/components" FILES ${COMPONENT_SOURCES})
+
+set(CORE_HEADERS_RELATIVE
+  "include/core/authorization.h"
+  "include/core/exception.h"
+  "include/core/netimpl.h"
+  "include/core/network.h"
+  "include/core/response.h"
+)
+
+make_absolute_paths(CORE_HEADERS ${CORE_HEADERS_RELATIVE})
+source_group("include/core" FILES ${CORE_HEADERS})
+
+set(CORE_SOURCES_RELATIVE
+  "core/authorization.cpp"
+  "core/netimpl.cpp"
+  "core/response.cpp"
+)
+
+make_absolute_paths(CORE_SOURCES ${CORE_SOURCES_RELATIVE})
+source_group("source/core" FILES ${CORE_SOURCES})
+
+target_sources(${PROJECT_NAME}
+  PRIVATE
+    ${COMPONENT_SOURCES}
+    ${CORE_SOURCES}
+  PUBLIC
+    "$<BUILD_INTERFACE:${HEADERS}>"
+    "$<BUILD_INTERFACE:${COMPONENT_HEADERS}>"
+    "$<BUILD_INTERFACE:${CORE_HEADERS}>"
+    "$<INSTALL_INTERFACE:${HEADERS_RELATIVE}>"
+    "$<INSTALL_INTERFACE:${COMPONENT_HEADERS_RELATIVE}>"
+    "$<INSTALL_INTERFACE:${CORE_HEADERS_RELATIVE}>"
+)
+
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
+
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    nlohmann_json::nlohmann_json
+    CURL::libcurl
+)
+
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>"
+)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION lib EXPORT ${PROJECT_NAME}Targets)
+install(FILES ${HEADERS} DESTINATION "include")
+install(FILES ${COMPONENT_HEADERS} DESTINATION "include/components")
+install(FILES ${CORE_HEADERS} DESTINATION "include/core")
+
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION "lib/cmake/${PROJECT_NAME}"
+)
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  COMPATIBILITY AnyNewerVersion
+)
+
+install(EXPORT ${PROJECT_NAME}Targets
+  FILE ${PROJECT_NAME}Targets.cmake
+  NAMESPACE oai::
+  DESTINATION "lib/cmake/${PROJECT_NAME}"
+)
 install(FILES
-include/components/audio.h
-include/components/azure.h
-include/components/chat.h
-include/components/completions.h
-include/components/edits.h
-include/components/embeddings.h
-include/components/files.h
-include/components/fine_tunes.h
-include/components/images.h
-include/components/models.h
-include/components/moderations.h
-DESTINATION include/components)
-install(FILES
-include/core/authorization.h
-include/core/exception.h
-include/core/netimpl.h
-include/core/network.h
-include/core/response.h
-DESTINATION include/core)
-
-set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT oai)
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  DESTINATION "lib/cmake/${PROJECT_NAME}"
+)

--- a/liboai/Config.cmake.in
+++ b/liboai/Config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/oaiTargets.cmake")
+
+find_package(nlohmann_json CONFIG REQUIRED)
+find_package(CURL REQUIRED)

--- a/liboai/include/core/netimpl.h
+++ b/liboai/include/core/netimpl.h
@@ -32,12 +32,6 @@
 		cURL for People (CPR).
 */
 
-#if defined(__linux__) || defined(__APPLE__)
-	#define LIBOAI_EXPORT
-#else
-	#define LIBOAI_EXPORT __declspec(dllexport)
-#endif
-
 #include <fstream>
 #include <optional>	
 #include <mutex>
@@ -61,12 +55,9 @@ namespace liboai {
 		class CurlHolder {
 			public:
 				CurlHolder();
+				NON_COPYABLE(CurlHolder)
+				NON_MOVABLE(CurlHolder)
 				virtual ~CurlHolder();
-				CurlHolder(const CurlHolder&) = delete;
-				CurlHolder(CurlHolder&&) = delete;
-
-				CurlHolder& operator=(const CurlHolder&) = delete;
-				CurlHolder& operator=(CurlHolder&&) = delete;
 
 				std::string urlEncode(const std::string& s);
 				std::string urlDecode(const std::string& s);
@@ -103,7 +94,6 @@ namespace liboai {
 					virtual ~StringHolder() = default;
 
 					StringHolder& operator=(StringHolder&& old) noexcept = default;
-
 					StringHolder& operator=(const StringHolder& other) = default;
 
 					explicit operator std::string() const {
@@ -576,8 +566,8 @@ namespace liboai {
 			class WriteCallback final {
 				public:
 					WriteCallback() = default;
-					WriteCallback(const WriteCallback& other) : userdata(other.userdata), callback(other.callback) {}
-					WriteCallback(WriteCallback&& old) noexcept : userdata(std::move(old.userdata)), callback(std::move(old.callback)) {}
+					WriteCallback(const WriteCallback& other) : callback(other.callback), userdata(other.userdata) {}
+					WriteCallback(WriteCallback&& old) noexcept : callback(std::move(old.callback)), userdata(std::move(old.userdata)) {}
 					WriteCallback(std::function<bool(std::string data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0)
 						: userdata(p_userdata), callback(std::move(p_callback)) {}
 


### PR DESCRIPTION
Added various improvements for the CMake build files:
- Native support for find_package: find_package(oai REQUIRED), target_link_libraries([target] PRIVATE oai::oai)
- Version for find_package has to be set in liboai/CMakeLists.txt now for each release
- Compileable examples via the compile option BUILD_EXAMPLES
- Debug postfix for Microsoft compilers to allow the installation of Debug and Release libraries
- Source groupings
- Correction for the scope of some target properties
- Exclusion of folders generated by Visual Studio CMake integration