### PR TITLE
Fix some bugs that are relatively difficult to reproduce.

### DIFF
--- a/liboai/core/netimpl.cpp
+++ b/liboai/core/netimpl.cpp
@@ -701,6 +701,7 @@ void liboai::netimpl::Session::ClearContext() {
   url_.clear();
   response_string_.clear();
   header_string_.clear();
+  write_ = netimpl::components::WriteCallback{};
 }
 
 void liboai::netimpl::Session::ParseResponseHeader(const std::string& headers, std::string* status_line, std::string* reason) {

--- a/liboai/include/components/chat.h
+++ b/liboai/include/components/chat.h
@@ -803,6 +803,7 @@ namespace liboai {
 			nlohmann::json _conversation;
 			std::optional<nlohmann::json> _functions = std::nullopt;
 			bool _last_resp_is_fc = false;
+			std::string _last_incomplete_buffer;
 	};
 
 	class ChatCompletion final : private Network {


### PR DESCRIPTION
1. The reset of write_ was missing for ClearContext. This caused the next request to still use the previous callback setting, resulting in unexpected behavior.
2. Fix the JSON parsing error caused by the truncation of the message body in the chat stream mode.
