### PR TITLE
Avoid GCC warnings about missing declarations of operator<< in namespace liboai

### DIFF
--- a/liboai/components/chat.cpp
+++ b/liboai/components/chat.cpp
@@ -661,10 +661,14 @@ liboai::FutureResponse liboai::ChatCompletion::create_async(const std::string& m
 	return std::async(std::launch::async, &liboai::ChatCompletion::create, this, model, std::ref(conversation), function_call, temperature, top_p, n, stream, stop, max_tokens, presence_penalty, frequency_penalty, logit_bias, user);
 }
 
-std::ostream& liboai::operator<<(std::ostream& os, const Conversation& conv) {
+namespace liboai {
+
+std::ostream& operator<<(std::ostream& os, const Conversation& conv) {
 	os << conv.GetRawConversation() << std::endl << (conv.HasFunctions() ? conv.GetRawFunctions() : "");
 
 	return os;
+}
+
 }
 
 liboai::Functions::Functions() {

--- a/liboai/core/response.cpp
+++ b/liboai/core/response.cpp
@@ -61,9 +61,13 @@ liboai::Response& liboai::Response::operator=(liboai::Response&& other) noexcept
 	return *this;
 }
 
-std::ostream& liboai::operator<<(std::ostream& os, const Response& r) {
+namespace liboai {
+
+std::ostream& operator<<(std::ostream& os, const Response& r) {
 	!r.raw_json.empty() ? os << r.raw_json.dump(4) : os << "null";
 	return os;
+}
+
 }
 
 void liboai::Response::CheckResponse() const noexcept(false) {


### PR DESCRIPTION
A small change to avoid default GCC warnings.