### PR TITLE
Issue 79: Make download_generated_image example compile again.

### DIFF
--- a/documentation/images/examples/CMakeLists.txt
+++ b/documentation/images/examples/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.13)
 project(images)
 
 # compilation error
-#add_basic_example(download_generated_image)
+add_basic_example(download_generated_image)
 add_basic_example(generate_edit)
 add_basic_example(generate_edit_async)
 add_basic_example(generate_image)

--- a/documentation/images/examples/download_generated_image.cpp
+++ b/documentation/images/examples/download_generated_image.cpp
@@ -10,8 +10,9 @@ int main() {
         "a siamese cat!"
       );
       Network::Download(
-        "C:/some/folder/file.png",                    // to
-        response["data"][0]["url"].get<std::string>() // from
+        "C:/some/folder/file.png",                     // to
+        response["data"][0]["url"].get<std::string>(), // from
+        netimpl::components::Header()
       );
     }
     catch (std::exception& e) {


### PR DESCRIPTION
Pass an empty headers map for the last argument.

https://github.com/D7EAD/liboai/issues/79
