### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs
-build
+[Bb]uild*
 out
 TestApp
+.cache


### PR DESCRIPTION
This makes it possible to have multiple build directories, for example for cross compilation. It also adds an entry for ".cache" which is a directory created by clangd.